### PR TITLE
Add setup and auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.venv/
+personal/
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # murgenere-web
 
-A wraper for murgenere.com and my.murgenere.com.
+This repository contains a small Flask application used to serve
+`murgenere.com` and `my.murgenere.com`.
+
+## Installation
+
+Run the provided `setup.py` script to create a virtual environment,
+install dependencies and clone the private Streamlit repository:
+
+```bash
+python setup.py
+source .venv/bin/activate
+```
+
+## Running
+
+```
+python -m app.main
+```
+
+If `/my` should be protected, set `MY_USERNAME` and `MY_PASSWORD` in the
+environment before launching the server.
+
+The root page (`/`) will display an image for `murgenere.com`.
+
+Accessing `/my` will redirect to a Streamlit application assumed to be
+running locally. Set the `STREAMLIT_URL` environment variable if the
+Streamlit app runs on a different URL.
+
+The setup script clones the
+[`filippobounous/personal`](https://github.com/filippobounous/personal)
+repository under `./personal`. Launch its Streamlit interface with:
+
+```bash
+cd personal
+streamlit run app.py
+```
+
+Once running, visiting `/my` on this Flask server will redirect to the
+Streamlit app (default `http://localhost:8501`).
+Authentication for `/my` is optional; provide `MY_USERNAME` and
+`MY_PASSWORD` environment variables to enable HTTP basic auth.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,40 @@
+from flask import Flask, render_template, redirect, request, Response
+from functools import wraps
+from os import getenv
+
+
+def create_app():
+    app = Flask(__name__)
+
+    def check_auth(username, password):
+        user = getenv('MY_USERNAME')
+        pw = getenv('MY_PASSWORD')
+        if user and pw:
+            return username == user and password == pw
+        return True  # auth disabled if creds missing
+
+    def authenticate():
+        return Response('Authentication required', 401,
+                        {'WWW-Authenticate': 'Basic realm="Login"'})
+
+    def requires_auth(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            auth = request.authorization
+            if not check_auth(*(auth or (None, None))):
+                return authenticate()
+            return f(*args, **kwargs)
+        return decorated
+
+    @app.route('/')
+    def index():
+        return render_template('index.html')
+
+    @app.route('/my')
+    @requires_auth
+    def my():
+        # Redirects to the local streamlit app
+        streamlit_url = getenv('STREAMLIT_URL', 'http://localhost:8501')
+        return redirect(streamlit_url)
+
+    return app

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,6 @@
+from . import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>murgenere</title>
+  </head>
+  <body>
+    <img src="https://placehold.co/600x400?text=murgenere" alt="murgenere">
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+streamlit
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Setup script for murgenere-web.
+
+Creates a virtual environment, installs dependencies,
+and clones the private Streamlit repository used for
+`my.murgenere.com`.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def run(cmd):
+    print("Running:", " ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+def main():
+    root = Path(__file__).parent
+    venv = root / '.venv'
+
+    if not venv.exists():
+        run(['python3', '-m', 'venv', str(venv)])
+
+    python = venv / 'bin' / 'python'
+    run([str(python), '-m', 'pip', 'install', '--upgrade', 'pip'])
+    run([str(python), '-m', 'pip', 'install', '-r', 'requirements.txt'])
+
+    personal_repo = root / 'personal'
+    if not personal_repo.exists():
+        run(['git', 'clone', 'https://github.com/filippobounous/personal.git', str(personal_repo)])
+    else:
+        run(['git', '-C', str(personal_repo), 'pull'])
+
+    print('\nSetup complete.')
+    print(f'Activate the virtual environment with: source {venv}/bin/activate')
+    print('Run the Flask server with: python -m app.main')
+    print('Launch the Streamlit app with: streamlit run app.py (inside ./personal)')
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- add setup script for installing dependencies and cloning the private repo
- secure the `/my` route with optional basic auth
- document setup instructions and auth usage
- include Streamlit in requirements and ignore the private repo directory

## Testing
- `python -m py_compile app/__init__.py app/main.py setup.py`
- `python -m app.main` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_b_68638dc20ae08325a30627f1ce44c73b